### PR TITLE
Remove punctuation from links.  Use relative links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 > Clean reimplementation of \"BatchBALD: Efficient and Diverse Batch Acquisition for Deep Bayesian Active Learning\"
 
 
-For an introduction & more information, see https://blackhc.github.io/BatchBALD/. The paper can be found at http://arxiv.org/abs/1906.08158. The documentation for this version can be found under https://blackhc.github.io/batchbald_redux/.
+For an introduction & more information, see [https://blackhc.github.io/BatchBALD/](https://blackhc.github.io/BatchBALD/). The paper can be found at [http://arxiv.org/abs/1906.08158](http://arxiv.org/abs/1906.08158). The documentation for this version can be found under [https://github.com/BlackHC/batchbald_redux/](https://github.com/BlackHC/batchbald_redux/).
 
-The original implementation used in the paper is available at https://github.com/BlackHC/BatchBALD.
+The original implementation used in the paper is available at [https://github.com/BlackHC/BatchBALD](https://github.com/BlackHC/BatchBALD).
 
 We are grateful for fastai's [nbdev](https://nbdev.fast.ai/) which is powering this package.
 
 For more information, explore the sections and notebooks in the left-hand menu.
-The code is available on https://github.com/BlackHC/batchbald_redux, 
-and the website on https://blackhc.github.io/batchbald_redux.
+The code is available on [https://github.com/BlackHC/batchbald_redux](https://github.com/BlackHC/batchbald_redux),
+and the website on [https://blackhc.github.io/batchbald_redux](https://blackhc.github.io/batchbald_redux).
 
 ## Install
 
@@ -26,7 +26,7 @@ The aquisition function is the mutual information between the joint of a candida
 $$a_{\text{BatchBALD}}((y_b)_B) = I[(y_b)_B;\omega]$$
 {% endraw %}
 
-The best candidate batch is one that maximizes this acquisition function. 
+The best candidate batch is one that maximizes this acquisition function.
 
 In the paper, we show that this function satisfies sub-modularity, which provides us an optimality guarantee for a greedy algorithm. The candidate batch is selected using greedy expansion.
 
@@ -49,9 +49,9 @@ To aid reproducibility and baseline reproduction, we provide this simpler and cl
 
 ## How to use
 
-We provide a simple example experiment that uses this package [here](https://blackhc.github.io/batchbald_redux/example_experiment/). 
+We provide a simple example experiment that uses this package [here](docs/example_experiment.html).
 
-To get a candidate batch using BatchBALD, we provide a simple API in [`batchbald_redux.batchbald`](https://blackhc.github.io/batchbald_redux/batchbald/):
+To get a candidate batch using BatchBALD, we provide a simple API in [`batchbald_redux.batchbald.py`](batchbald_redux/batchbald.py):
 
 
 <h4 id="get_batchbald_batch" class="doc_header"><code>get_batchbald_batch</code><a href="https://github.com/blackhc/batchbald_redux/tree/master/batchbald_redux/batchbald.py#L67" class="source_link" style="float:right">[source]</a></h4>
@@ -61,4 +61,4 @@ To get a candidate batch using BatchBALD, we provide a simple API in [`batchbald
 
 
 
-We also provide a simple implementation of consistent MC dropout in [`batchbald_redux.consistent_mc_dropout`](https://blackhc.github.io/batchbald_redux/consistent_mc_dropout/).
+We also provide a simple implementation of consistent MC dropout in [`batchbald_redux.consistent_mc_dropout.py`](batchbald_redux/consistent_mc_dropout.py).


### PR DESCRIPTION
Some links that were straight text rather than Markdown link syntax failed in some circumstances due to punctuation that was not supposed to be part of the link.  These have been replaced with Markdown link syntax.

Replaced some absolute links with relative links, for cases where forcing the user back onto GitHub.com is not called for.